### PR TITLE
feature: back to index link for easier slides navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           <h3>Redefining your education.</h3>
         </section>
 
-        <section>
+        <section id="contents">
           <h2>Table of Contents</h2>
 
           <div style="font-size: 0.8em; display: flex;">

--- a/m1.html
+++ b/m1.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m1;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m10.html
+++ b/m10.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m10;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m2.html
+++ b/m2.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m2;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m3.html
+++ b/m3.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m3;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <!-- <section>

--- a/m4.html
+++ b/m4.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m4;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m5.html
+++ b/m5.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m5;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m6.html
+++ b/m6.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m6;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m7.html
+++ b/m7.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m7;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m8.html
+++ b/m8.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m8;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>

--- a/m9.html
+++ b/m9.html
@@ -56,6 +56,7 @@
           <img src="./assets/academy-logo-text-black.png" />
           <h3>Redefining your education.</h3>
           <pre><code class="hljs js">const module = m9;</code></pre>
+          <a href="/index.html#contents" style="font-size: x-large">Back to index</a>
         </section>
 
         <section>


### PR DESCRIPTION
I was looking through all the slides and found it annoying that there was no link for me to navigate back to the table of contents so I could go to the next set of sides easily. I just added a little link at the beginning of each slide deck for that purpose. This saves time for anybody wanting to look over all the different slide decks.